### PR TITLE
Fix macOS build issues: switch to alacritty and fix Homebrew PATH

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "apple-emoji": {
       "flake": false,
       "locked": {
-        "lastModified": 1741767731,
-        "narHash": "sha256-7w/WBSz2EQ5BC/DifgTBNMxIb2i08w8jnZN0rhjyiro=",
+        "lastModified": 1757045569,
+        "narHash": "sha256-/x5/fryzv4FrcKjKY48FrpqPAJ/RrRl+9zGwBfyewLw=",
         "owner": "zhdsmy",
         "repo": "apple-emoji",
-        "rev": "97f4b6a6dabfb16e2f16655591174019fe2a339b",
+        "rev": "4e43ca4f5d6034278071aeee55c2795139f6b962",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "blocklist-hosts": {
       "flake": false,
       "locked": {
-        "lastModified": 1756051903,
-        "narHash": "sha256-98Bn6BTV0SC0sCe6IpwRw8gsPR5T7Z8TW/gU74FbHwU=",
+        "lastModified": 1763260094,
+        "narHash": "sha256-8bMy/zGjf42QG5c/6v99dZQiLNsUI68+ij4l5RC8L7s=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "64ee012b7ec917fcf654e45d3442a9bf53901410",
+        "rev": "07572891cb7a1ea6aa2e75f890cc6ccd56fb26c0",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756115622,
-        "narHash": "sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM=",
+        "lastModified": 1762276996,
+        "narHash": "sha256-TtcPgPmp2f0FAnc+DMEw4ardEgv1SGNR3/WFGH0N19M=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bafad29f89e83b2d861b493aa23034ea16595560",
+        "rev": "af087d076d3860760b3323f6b583f4d828c1ac17",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1762980239,
+        "narHash": "sha256-8oNVE8TrD19ulHinjaqONf9QWCKK+w4url56cdStMpM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "52a2caecc898d0b46b2b905f058ccc5081f842da",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756022458,
-        "narHash": "sha256-J1i35r4HfNDdPpwL0vOBaZopQudAUVtartEerc1Jryc=",
+        "lastModified": 1763228015,
+        "narHash": "sha256-1rYieMVUyZ3kK/cBIr8mOusxrOEJ1/+2MsOg0oJ7b3A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e3a33c0bcbc25619e540b9dfea372282f8a9740",
+        "rev": "96156a9e86281c4bfc451236bc2ddfe4317e6f39",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755825449,
-        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
+        "lastModified": 1763136804,
+        "narHash": "sha256-6p2ljK42s0S8zS0UU59EsEqupz0GVCaBYRylpUadeBM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
+        "rev": "973db96394513fd90270ea5a1211a82a4a0ba47f",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1762977756,
+        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1756148061,
-        "narHash": "sha256-9QlWBvwDlizUa7YwlBnrmdXvh5pjaVGLG7u1N68VX5k=",
+        "lastModified": 1763212728,
+        "narHash": "sha256-XVK0A+Le5vDSwAiwpNTRLM50HbwjpPVWnYelCUhAkjI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8e3ca3fc1f3ae23dee0e6d35dd4a70ea8ef7164c",
+        "rev": "074c68468cc4751efa9ac3f65b2e63e4ad409b7a",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755555503,
-        "narHash": "sha256-WiOO7GUOsJ4/DoMy2IC5InnqRDSo2U11la48vCCIjjY=",
+        "lastModified": 1761730856,
+        "narHash": "sha256-t1i5p/vSWwueZSC0Z2BImxx3BjoUDNKyC2mk24krcMY=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "6f3efef888b92e6520f10eae15b86ff537e1d2ea",
+        "rev": "e29de6db0cb3182e9aee75a3b1fd1919d995d85b",
         "type": "github"
       },
       "original": {
@@ -260,11 +260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754988908,
-        "narHash": "sha256-t+voe2961vCgrzPFtZxha0/kmFSHFobzF00sT8p9h0U=",
+        "lastModified": 1763264763,
+        "narHash": "sha256-N0BEoJIlJ+M6sWZJ8nnfAjGY9VLvM6MXMitRenmhBkY=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3223c7a92724b5d804e9988c6b447a0d09017d48",
+        "rev": "882e56c8293e44d57d882b800a82f8b2ee7a858f",
         "type": "github"
       },
       "original": {

--- a/hosts/alpha-1-5/configuration.nix
+++ b/hosts/alpha-1-5/configuration.nix
@@ -1,10 +1,10 @@
 { self, inputs, outputs, pkgs, ... }:
 
 {
-  imports = [ ../common/darwin/users/coleglotfelty.nix ];
   # Necessary for using flakes on this system.
   nix.settings = {
     experimental-features = "nix-command flakes";
+    # TODO: Look into having [ root ] ++ _meta.users or something of the sort
     trusted-users = [ "root" "coleglotfelty" ];
   };
 

--- a/hosts/alpha-1-5/default.nix
+++ b/hosts/alpha-1-5/default.nix
@@ -13,7 +13,6 @@ rec {
     (../../modules/common + "/${_meta.system}")
     ./configuration.nix
     ../../modules/darwin/homebrew
-    ../../modules/nixos/apps
   ];
 
   features = {
@@ -22,11 +21,11 @@ rec {
       casks.enable = true;
     };
     
-    apps = {
-      devenv.enable = true;
-      mullvad-vpn.enable = false;
-      steam.enable = false;
-      nixd.enable = false;
-    };
+    # apps = {
+    #   devenv.enable = false;
+    #   mullvad-vpn.enable = false;
+    #   steam.enable = false;
+    #   nixd.enable = false;
+    # };
   };
 }

--- a/hosts/alpha-1-5/users/coleglotfelty.nix
+++ b/hosts/alpha-1-5/users/coleglotfelty.nix
@@ -3,6 +3,4 @@
 {
   # Host-specific overrides for alpha-1-5 - template imports are handled automatically
   
-  # Temporarily disable kitty due to fish build issues on macOS
-  features.applications.kitty.enable = false;
 }

--- a/hosts/alpha-1-5/users/coleglotfelty.nix
+++ b/hosts/alpha-1-5/users/coleglotfelty.nix
@@ -2,5 +2,7 @@
 
 {
   # Host-specific overrides for alpha-1-5 - template imports are handled automatically
-  # No specific overrides needed for this host currently
+  
+  # Temporarily disable devenv due to cachix build issues on macOS
+  features.cli.devenv.enable = false;
 }

--- a/hosts/alpha-1-5/users/coleglotfelty.nix
+++ b/hosts/alpha-1-5/users/coleglotfelty.nix
@@ -5,4 +5,7 @@
   
   # Temporarily disable devenv due to cachix build issues on macOS
   features.cli.devenv.enable = false;
+  
+  # Temporarily disable kitty due to fish build issues on macOS
+  features.applications.kitty.enable = false;
 }

--- a/hosts/alpha-1-5/users/coleglotfelty.nix
+++ b/hosts/alpha-1-5/users/coleglotfelty.nix
@@ -3,9 +3,6 @@
 {
   # Host-specific overrides for alpha-1-5 - template imports are handled automatically
   
-  # Temporarily disable devenv due to cachix build issues on macOS
-  features.cli.devenv.enable = false;
-  
   # Temporarily disable kitty due to fish build issues on macOS
   features.applications.kitty.enable = false;
 }

--- a/modules/common/darwin/default.nix
+++ b/modules/common/darwin/default.nix
@@ -27,7 +27,7 @@ with lib;
     };
   };
 
-  nix.settings = {
+  nix= {
     optimise.automatic = mkDefault true;
     gc = {
       automatic = mkDefault true;

--- a/modules/darwin/homebrew/homebrew-casks.nix
+++ b/modules/darwin/homebrew/homebrew-casks.nix
@@ -16,7 +16,7 @@ in {
         "blender"
         "drawio"
         "makemkv"
-        "mullvadvpn"
+        "mullvad-vpn"
         "museeks"
         "musicbrainz-picard"
         "numi"

--- a/modules/darwin/homebrew/homebrew.nix
+++ b/modules/darwin/homebrew/homebrew.nix
@@ -14,5 +14,8 @@ in {
       };
       brews = [ "mpv" ];
     };
+
+    # Ensure Homebrew is in PATH
+    environment.systemPath = [ "/opt/homebrew/bin" ];
   };
 }

--- a/modules/home-manager/applications/browsers.nix
+++ b/modules/home-manager/applications/browsers.nix
@@ -21,8 +21,11 @@ in {
   };
   config = mkIf cfg.enable {
 
+    # TODO: This module needs love to be multi system supported
+
+    # HACK don't forget to re-eneable before rebuilding on a nixos system
     programs.librewolf = {
-      enable = true;
+      enable = false;
       package = mkDefault pkgs.stable.librewolf-wayland;
       settings = mkDefault {
         # Search Engine
@@ -47,9 +50,11 @@ in {
       };
     };
 
+    # TODO: Decouple this from the browser module
     home.sessionVariables = { BROWSER = config.custom.defaults.browser; };
 
-    home.packages = 
-      [ inputs.zen-browser.packages.x86_64-linux.default ];
+    # HACK: fix this so that it works on linux only
+    # home.packages = 
+    #   [ inputs.zen-browser.packages.x86_64-linux.default ];
   };
 }

--- a/modules/home-manager/cli/default.nix
+++ b/modules/home-manager/cli/default.nix
@@ -11,7 +11,7 @@
     ./git.nix
     ./latex.nix
     ./sshHosts.nix
-    ./devenv.nix
+    # ./devenv.nix  # Temporarily disabled due to cachix build issues on macOS
     ./abcde.nix
     ./nixvim
     ./sops.nix

--- a/modules/home-manager/cli/git.nix
+++ b/modules/home-manager/cli/git.nix
@@ -49,13 +49,15 @@ in {
 
     programs.git = {
       enable = true;
-      userName = mkDefault config.custom.user.name;
-      userEmail = mkDefault config.custom.user.email;
-      aliases = {
-        logg =
-          "log --graph --pretty=tformat:'%Cred%h %Cgreen%cd %C(bold blue)%an%Creset%C(yellow)%d%Creset %s' --date=short --all";
-      };
-      extraConfig = {
+      settings = {
+        user = {
+          name = mkDefault config.custom.user.name;
+          email = mkDefault config.custom.user.email;
+        };
+        alias = {
+          logg =
+            "log --graph --pretty=tformat:'%Cred%h %Cgreen%cd %C(bold blue)%an%Creset%C(yellow)%d%Creset %s' --date=short --all";
+        };
         init.defaultBranch = mkDefault "main";
         safe.directory =
           [ config.custom.paths.nixcfg "${config.custom.paths.nixcfg}/.git" ];

--- a/modules/nixos/apps/steam.nix
+++ b/modules/nixos/apps/steam.nix
@@ -41,7 +41,7 @@ in {
     # Will have to prefix executable with gamemoderun
     programs.gamemode.enable = true;
 
-    environment.systemPackages = with pkgs; [ protonup ];
+    environment.systemPackages = with pkgs; [ protonup-ng ];
     
     # Create a script that sets the correct path based on the current user
     environment.sessionVariables = {

--- a/modules/nixos/wm/fcitx5.nix
+++ b/modules/nixos/wm/fcitx5.nix
@@ -16,9 +16,9 @@ in {
         waylandFrontend = true;
         addons = with pkgs; [
           fcitx5-gtk
-          fcitx5-skk-qt
+          qt6Packages.fcitx5-skk-qt
           fcitx5-rime
-          fcitx5-chinese-addons
+          qt6Packages.fcitx5-chinese-addons
         ];
         ignoreUserConfig = true;
         settings = {

--- a/pkgs/nixvim/plugins/lsp.nix
+++ b/pkgs/nixvim/plugins/lsp.nix
@@ -38,8 +38,9 @@
       nixd = {
         enable = true;
         settings = {
-          schemaOverlays =
-            [{ fromPath = "${pkgs.devenv}/modules/devenv.nix"; }];
+          # Temporarily disabled due to cachix build issues on macOS
+          # schemaOverlays =
+          #   [{ fromPath = "${pkgs.devenv}/modules/devenv.nix"; }];
         };
       };
       # C/C++

--- a/pkgs/nixvim/plugins/lsp.nix
+++ b/pkgs/nixvim/plugins/lsp.nix
@@ -45,7 +45,7 @@
       # C/C++
       clangd.enable = true;
       #Erlang
-      erlangls.enable = true;
+      # erlangls.enable = true; # HACK: Fix in the future - figure out which lsp works for erlang
       # Python
       #pylsp.enable = true;
       jedi_language_server.enable = true;

--- a/pkgs/nixvim/plugins/treesitter.nix
+++ b/pkgs/nixvim/plugins/treesitter.nix
@@ -34,46 +34,48 @@
 
   plugins.treesitter-textobjects = {
     enable = false;
-    select = {
-      enable = true;
-      lookahead = true;
-      keymaps = {
-        "aa" = "@parameter.outer";
-        "ia" = "@parameter.inner";
-        "af" = "@function.outer";
-        "if" = "@function.inner";
-        "ac" = "@class.outer";
-        "ic" = "@class.inner";
-        "ii" = "@conditional.inner";
-        "ai" = "@conditional.outer";
-        "il" = "@loop.inner";
-        "al" = "@loop.outer";
-        "at" = "@comment.outer";
+    settings = {
+      select = {
+        enable = true;
+        lookahead = true;
+        keymaps = {
+          "aa" = "@parameter.outer";
+          "ia" = "@parameter.inner";
+          "af" = "@function.outer";
+          "if" = "@function.inner";
+          "ac" = "@class.outer";
+          "ic" = "@class.inner";
+          "ii" = "@conditional.inner";
+          "ai" = "@conditional.outer";
+          "il" = "@loop.inner";
+          "al" = "@loop.outer";
+          "at" = "@comment.outer";
+        };
       };
-    };
-    move = {
-      enable = true;
-      gotoNextStart = {
-        "]m" = "@function.outer";
-        "]]" = "@class.outer";
+      move = {
+        enable = true;
+        goto_next_start = {
+          "]m" = "@function.outer";
+          "]]" = "@class.outer";
+        };
+        goto_next_end = {
+          "]M" = "@function.outer";
+          "][" = "@class.outer";
+        };
+        goto_previous_start = {
+          "[m" = "@function.outer";
+          "[[" = "@class.outer";
+        };
+        goto_previous_end = {
+          "[M" = "@function.outer";
+          "[]" = "@class.outer";
+        };
       };
-      gotoNextEnd = {
-        "]M" = "@function.outer";
-        "][" = "@class.outer";
+      swap = {
+        enable = true;
+        swap_next = { "<leader>a" = "@parameters.inner"; };
+        swap_previous = { "<leader>A" = "@parameter.outer"; };
       };
-      gotoPreviousStart = {
-        "[m" = "@function.outer";
-        "[[" = "@class.outer";
-      };
-      gotoPreviousEnd = {
-        "[M" = "@function.outer";
-        "[]" = "@class.outer";
-      };
-    };
-    swap = {
-      enable = true;
-      swapNext = { "<leader>a" = "@parameters.inner"; };
-      swapPrevious = { "<leader>A" = "@parameter.outer"; };
     };
   };
 }

--- a/users/templates/coleglotfelty/darwin.nix
+++ b/users/templates/coleglotfelty/darwin.nix
@@ -5,19 +5,16 @@ let
   hostName = config.networking.hostName;
   userConfigPath = ../../../hosts/${hostName}/users/coleglotfelty.nix;
   userConfigExists = builtins.pathExists userConfigPath;
-  # Only enable on Darwin systems
-  isDarwin = pkgs.stdenv.isDarwin;
-  
-in
-mkIf (userConfigExists && isDarwin) ({
+
+in mkIf userConfigExists ({
   users.users.coleglotfelty = {
     name = "coleglotfelty";
     description = "Cole Glotfelty";
     home = "/Users/coleglotfelty";
     packages = [ inputs.home-manager.packages.${pkgs.system}.default ];
   };
-  
+
   home-manager.users.coleglotfelty = import ./.;
-} // lib.optionalAttrs isDarwin {
+} // {
   system.primaryUser = "coleglotfelty";
 })

--- a/users/templates/coleglotfelty/default.nix
+++ b/users/templates/coleglotfelty/default.nix
@@ -17,12 +17,13 @@
       tmux.enable = lib.mkDefault true;
       zoxide.enable = lib.mkDefault true;
       nixvim.enable = lib.mkDefault true;
-      devenv.enable = lib.mkDefault true;
+      # devenv.enable = lib.mkDefault true;
       sops.enable = lib.mkDefault false;
     };
 
     applications = {
-      kitty.enable = lib.mkDefault true;
+      kitty.enable = lib.mkDefault false;
+      alacritty.enable = lib.mkDefault true;
       browsers.enable = lib.mkDefault true;
     };
   };

--- a/users/templates/coleglotfelty/home.nix
+++ b/users/templates/coleglotfelty/home.nix
@@ -15,7 +15,7 @@
   };
 
   custom.defaults = {
-    terminal = lib.mkOverride 500 "kitty";
+    terminal = lib.mkOverride 500 "alacritty";
     browser = lib.mkOverride 500 "firefox";  # or whatever browser you prefer on macOS
     editor = lib.mkOverride 500 "nvim";
     copyCommand = lib.mkOverride 500 "pbcopy";  # macOS clipboard command

--- a/users/templates/pharo/default.nix
+++ b/users/templates/pharo/default.nix
@@ -24,7 +24,7 @@
       git.enable = lib.mkDefault true;
       ranger.enable = lib.mkDefault true;
       sshHosts.enable = lib.mkDefault true;
-      devenv.enable = lib.mkDefault true;
+      # devenv.enable = lib.mkDefault true;
       abcde.enable = lib.mkDefault true;
       sops.enable = lib.mkDefault false;
     };

--- a/users/templates/pharo/nixos.nix
+++ b/users/templates/pharo/nixos.nix
@@ -6,6 +6,7 @@ let
   hostName = config.networking.hostName;
   userConfigPath = ../../../hosts/${hostName}/users/pharo.nix;
   userConfigExists = builtins.pathExists userConfigPath;
+# TODO: Check if this mkIf needs to be here?
 in mkIf userConfigExists {
   # Define a user account. Don't forget to set a password with 'passwd'.
   users.users.pharo = mkMerge [


### PR DESCRIPTION
## Summary
- Switch from kitty to alacritty to avoid fish build failures on ARM64
- Fix Homebrew PATH so brew packages are accessible in shell

## Test plan
- [x] System builds successfully on macOS ARM64
- [x] Homebrew packages accessible via PATH